### PR TITLE
Bump node12 -> node16.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,5 +10,5 @@ inputs:
     default: '${{ github.token }}'
     required: false
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
Github Actions is deprecating Node 12, and is switching to Node 16. This commit bumps our `actions.yml` to match.

See: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Signed-off-by: Philip Conrad <philipaconrad@gmail.com>