### PR TITLE
Upgrade to Node.js 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ inputs:
     default: '${{ github.token }}'
     required: false
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
Upgrading to Node.js 20 as [Node.js 16 is end-of-life](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)