### PR TITLE
add npm to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,11 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+- package-ecosystem: "npm"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  groups:
+    dependencies:
+      patterns:
+        - "*"


### PR DESCRIPTION
looks like dependabot might have been updating `package.json` already without this change: https://github.com/open-policy-agent/setup-opa/pull/38 🤔 maybe these were for security vulnerabilities.

Got here because I noticed a deprecation warning when using `setup-opa` here: https://github.com/open-policy-agent/opa/actions/runs/20866592243/job/59959142678?pr=8203

```
(node:2100) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
```